### PR TITLE
Fix unnecessary escape characters

### DIFF
--- a/BOF-Template/Makefile
+++ b/BOF-Template/Makefile
@@ -23,8 +23,8 @@ all: *.cpp
     @$(MAKE) /A $(patsubst %.c,%.obj, $(patsubst %.cpp, %.obj, $(patsubsti %, $(IMDIR)\%, $**)))
 
     @if not exist "$(OUTDIR)" mkdir "$(OUTDIR)"
-    copy "$(IMDIR)\*.obj" "$(OUTDIR)"
-    del /F "$(OUTDIR)\*$(OUTEXT)"
+    copy "$(IMDIR)*.obj" "$(OUTDIR)"
+    del /F "$(OUTDIR)*$(OUTEXT)"
     ren "$(OUTDIR)*.obj" "*$(OUTEXT)"
 
 all-debug: *.cpp


### PR DESCRIPTION
It seems backslashes were used to "escape" the wildcard. This does not appear to be necessary. After removing the backslashes, my code built with no errors